### PR TITLE
parameterize job defn name as ${StackName}-defn

### DIFF
--- a/template/template.yaml
+++ b/template/template.yaml
@@ -167,7 +167,7 @@ Resources:
     Properties:
       Type: container
       PropagateTags: true
-      JobDefinitionName: FargateBatchJobDefinition
+      JobDefinitionName: !Sub ${StackName}-defn
       ContainerProperties:
         Image:
           Fn::Join:
@@ -312,6 +312,7 @@ Resources:
       Timeout: 30
       Environment:
         Variables:
+          BATCH_JOB_DEFN_NAME: !Sub "${StackName}-defn"
           BATCH_JOB_QUEUE_NAME: !Sub "${StackName}-queue"
           DYNAMO_TABLE_NAME: !Sub ${StackName}
       Role:
@@ -340,6 +341,7 @@ Resources:
               batch = boto3.client('batch')
               region = batch.meta.region_name
 
+              batch_job_defn_name = os.environ["BATCH_JOB_DEFN_NAME"]
               batch_job_queue_name = os.environ["BATCH_JOB_QUEUE_NAME"]
               db_table_name  = os.environ["DYNAMO_TABLE_NAME"]
 
@@ -351,7 +353,7 @@ Resources:
 
               response = batch.submit_job(jobName=batch_job_queue_name, 
                                           jobQueue=batch_job_queue_name, 
-                                          jobDefinition='FargateBatchJobDefinition', 
+                                          jobDefinition=batch_job_defn_name, 
                                           containerOverrides={
                                               "command": [ "python", "batch_processor.py", batchCommand  ],
                                               "environment": [ 

--- a/template/template_ec2.yaml
+++ b/template/template_ec2.yaml
@@ -110,7 +110,7 @@ Resources:
     Type: AWS::Batch::JobDefinition
     Properties:
       Type: container
-      JobDefinitionName: Ec2BatchJobDefinition
+      JobDefinitionName: !Sub ${StackName}-defn
       ContainerProperties:
         Image:
           Fn::Join:
@@ -184,6 +184,7 @@ Resources:
       Timeout: 30
       Environment:
         Variables:
+          BATCH_JOB_DEFN_NAME: !Sub "${StackName}-defn"
           BATCH_JOB_QUEUE_NAME: !Sub "${StackName}-queue"
           DYNAMO_TABLE_NAME: !Sub ${StackName}      
       Role:
@@ -212,6 +213,7 @@ Resources:
               batch = boto3.client('batch')
               region = batch.meta.region_name
 
+              batch_job_defn_name = os.environ["BATCH_JOB_DEFN_NAME"]
               batch_job_queue_name = os.environ["BATCH_JOB_QUEUE_NAME"]
               db_table_name  = os.environ["DYNAMO_TABLE_NAME"]
 
@@ -223,7 +225,7 @@ Resources:
 
               response = batch.submit_job(jobName=batch_job_queue_name, 
                                           jobQueue=batch_job_queue_name, 
-                                          jobDefinition='Ec2BatchJobDefinition', 
+                                          jobDefinition=batch_job_defn_name, 
                                           containerOverrides={
                                               "command": [ "python", "batch_processor.py", batchCommand  ],
                                               "environment": [ 


### PR DESCRIPTION
*Issue #9, if available:*

*Description of changes:*
Parameterize BatchJobDefinitionName as ${StackName}-defn.
In Lambda function, add environment variable BATCH_JOB_DEFN_NAME = ${StackName}-defn.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
